### PR TITLE
Use upper-case library name "Reprocessing" in bsconfig

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "reprocessing-example",
   "sources": "src",
-  "bs-dependencies": ["reprocessing"],
+  "bs-dependencies": ["Reprocessing"],
   "entries": [{
     "backend": "bytecode",
     "main-module": "IndexHot"


### PR DESCRIPTION
This reverts commit 41d35d200db2848d47f336951e37d6736ac0989d, which set the dependency name to be lower case.

This fixes the last of the package name-related build issues on Linux for me and renders a couple of big blue squares on the web build. The native build segfaults but I think that is unrelated.

Fixes #3.
Fixes #4.


