### PR TITLE
update livestream-flappybird branch dependencies

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "reprocessing-example",
   "sources": "src",
-  "bs-dependencies": ["Reprocessing"],
+  "bs-dependencies": ["reprocessing"],
   "entries": [{
     "backend": "bytecode",
     "main-module": "Indexhot"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "clean": "bsb -clean-world"
   },
   "dependencies": {
-    "reprocessing": "0.2.0"
+    "reprocessing": "^0.3.2"
   },
   "devDependencies": {
-    "bsb-native": "4.0.6"
+    "bsb-native": "^4.0.1100"
   }
 }


### PR DESCRIPTION
These are updates to make livestream-flappybird branch work with current reprocessing.